### PR TITLE
MPI will be linked only if it enabled.

### DIFF
--- a/cmake/find_dependencies.cmake
+++ b/cmake/find_dependencies.cmake
@@ -1,5 +1,7 @@
 
-find_package(MPI REQUIRED)
+if(mpi)
+ find_package(MPI REQUIRED)
+endif()
 
 find_package(VTK REQUIRED)
 if(${VTK_FOUND})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,9 @@ file(GLOB_RECURSE BIOMESH_SOURCES ${CMAKE_CURRENT_SOURCE_DIR} *.cpp)
 add_library(biomesh SHARED ${BIOMESH_HEADERS} ${BIOMESH_SOURCES})
 target_include_directories(biomesh PUBLIC ${PROJECT_SOURCE_DIR}/src
                                           ${PROJECT_BINARY_DIR}/include
-                                          ${MPI_CXX_INCLUDE_DIRS}
+                                          $<$<BOOL:${MPI_CXX_FOUND}>:${MPI_CXX_INCLUDE_DIRS}>
                           )
-target_link_libraries(biomesh PUBLIC ${MPI_CXX_LIBRARIES} ${VTK_LIBRARIES})
+target_link_libraries(biomesh PUBLIC
+$<$<BOOL:${MPI_CXX_FOUND}>:${MPI_CXX_LIBRARIES}>
+                           ${VTK_LIBRARIES}
+                     )


### PR DESCRIPTION
The -Dmpi flag turns MPI on/off.
The MPI library will be searched and linked
only if -Dmpi=yes.